### PR TITLE
Add unittests for the LF controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ if(BUILD_TESTING)
                        tests/test_robot_model_builder.cpp)
   target_link_libraries(test_robot_model_builder ${PROJECT_NAME}
                         example-robot-data::example-robot-data)
+
+  ament_auto_add_gtest(test_lf_controller tests/test_lf_controller.cpp)
+  target_link_libraries(test_lf_controller
+    ${PROJECT_NAME}
+    example-robot-data::example-robot-data
+  )
+
 endif()
 
 #

--- a/tests/test_lf_controller.cpp
+++ b/tests/test_lf_controller.cpp
@@ -1,0 +1,9 @@
+#include "gtest/gtest.h"
+
+#include "linear_feedback_controller/lf_controller.hpp"
+
+#include "example-robot-data/path.hpp"
+
+using namespace linear_feedback_controller;
+
+TEST(LfControllerTest, TODO) {}


### PR DESCRIPTION
This PR aims at adding the necessary unittests for the LF Controller class currently defined @ `include/linear_feedback_controller/lf_controller.hpp`.

Tested interfaces:
- [ ] Ctor / Dtor;
- [ ] `void initialize(const RobotModelBuilder::SharedPtr& rmb)`
- [ ] `const VectorXd& compute_control(const Sensor&, const Control&)`